### PR TITLE
Add fusermount3/mount.fuse3 and run_exports

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @asafkahlon
+* @asafkahlon @mbargull

--- a/README.md
+++ b/README.md
@@ -134,4 +134,5 @@ Feedstock Maintainers
 =====================
 
 * [@asafkahlon](https://github.com/asafkahlon/)
+* [@mbargull](https://github.com/mbargull/)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About libfuse
 
 Home: https://github.com/libfuse/libfuse
 
-Package license: LGPL-2.1
+Package license: LGPL-2.1-only AND GPL-2.0-only
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libfuse-feedstock/blob/master/LICENSE.txt)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -61,7 +61,7 @@ def main(args=None):
         help="Setup debug environment using `conda debug`",
     )
     p.add_argument(
-        "--output-id", help="If running debug, specifiy the output to setup."
+        "--output-id", help="If running debug, specify the output to setup."
     )
 
     ns = p.parse_args(args=args)

--- a/recipe/0001-Install-fusermount-init-script-into-sysconfdir.patch
+++ b/recipe/0001-Install-fusermount-init-script-into-sysconfdir.patch
@@ -1,0 +1,11 @@
+--- util/install_helper.sh
++++ util/install_helper.sh
+@@ -40,7 +40,7 @@
+         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
+ 
+ install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
+-        "${DESTDIR}/etc/init.d/fuse3"
++        "${DESTDIR}${sysconfdir}/init.d/fuse3"
+ 
+ 
+ if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then

--- a/recipe/0002-Enable-building-utils-on-CentOS-6.patch
+++ b/recipe/0002-Enable-building-utils-on-CentOS-6.patch
@@ -1,0 +1,35 @@
+--- util/meson.build
++++ util/meson.build
+@@ -1,3 +1,11 @@
++cfg = configuration_data()
++cc = meson.get_compiler('c')
++
++cfg.set('HAVE_SECUREBITS_H',
++         cc.has_header('linux/securebits.h',
++                       args: [ '-D_GNU_SOURCE' ]))
++
++
+ fuseconf_path = join_paths(get_option('prefix'), get_option('sysconfdir'), 'fuse.conf')
+ 
+ executable('fusermount3', ['fusermount.c', '../lib/mount_util.c'],
+--- util/mount.fuse.c
++++ util/mount.fuse.c
+@@ -22,7 +22,18 @@
+ #include <sys/prctl.h>
+ #include <sys/syscall.h>
+ #include <linux/capability.h>
++#ifdef HAVE_SECUREBITS_H
+ #include <linux/securebits.h>
++#else
++/* for RHEL/CentOS 6 */
++#define issecure_mask(X) (1 << (X))
++#define SECURE_NOROOT 0
++#define SECURE_NOROOT_LOCKED 1
++#define SECURE_NO_SETUID_FIXUP 2
++#define SECURE_NO_SETUID_FIXUP_LOCKED 3
++#define SECURE_KEEP_CAPS 4
++#define SECURE_KEEP_CAPS_LOCKED 5
++#endif
+ /* for 2.6 kernels */
+ #if !defined(SECBIT_KEEP_CAPS) && defined(SECURE_KEEP_CAPS)
+ #define SECBIT_KEEP_CAPS (issecure_mask(SECURE_KEEP_CAPS))

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
-meson --prefix=$PREFIX --libdir=lib -Dexamples=false -Dutils=false build
+meson \
+  --prefix="${PREFIX}" \
+  --libdir=lib \
+  --sbindir=bin \
+  -Dexamples=false \
+  -Duseroot=false -Dudevrulesdir="${PREFIX}/lib/udev/rules.d" \
+  build
 ninja -C build/
 ninja -C build/ install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
-{% set name = "libfuse" %}
 {% set version = "3.10.0" %}
 
 package:
-  name: {{ name }}
+  name: libfuse
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/releases/download/fuse-{{ version }}/fuse-{{ version }}.tar.xz
+  url: https://github.com/libfuse/libfuse/releases/download/fuse-{{ version }}/fuse-{{ version }}.tar.xz
   sha256: 26517954567f237a7dbcb532755ba0d2c77575c5d90db7566b6e40ec05b0a039
+  patches:
+    - 0001-Install-fusermount-init-script-into-sysconfdir.patch
+    - 0002-Enable-building-utils-on-CentOS-6.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
@@ -29,6 +31,8 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libfuse3${SHLIB_EXT}
     - test -f ${PREFIX}/include/fuse3/fuse.h
+    - 'mount.fuse3 2>&1 | grep -qF usage:'
+    - fusermount3 -V
 
 about:
   home: https://github.com/libfuse/libfuse
@@ -40,3 +44,4 @@ about:
 extra:
   recipe-maintainers:
     - asafkahlon
+    - mbargull

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 1
   skip: true  # [not linux]
+  run_exports:
+    - {{ pin_subpackage('libfuse', max_pin='x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,9 @@ build:
   number: 1
   skip: true  # [not linux]
   run_exports:
-    - {{ pin_subpackage('libfuse', max_pin='x.x') }}
+    # Seems to be quite stable between minor versions
+    # https://abi-laboratory.pro/?view=timeline&l=libfuse
+    - {{ pin_subpackage('libfuse', max_pin='x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
 
 about:
   home: https://github.com/libfuse/libfuse
-  license: LGPL-2.1
+  license: LGPL-2.1-only AND GPL-2.0-only
   license_file: LICENSE
   license_family: LGPL
   summary: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This adds the `fusermount3` and `mount.fuse3` binaries, addressing gh-2.
A `run_exports` for the library is also added as well as myself to the `recipe-maintainers` list.