### PR TITLE
MNT: refine license, add @xmnlab, gcc930 rebuild, remove libstdcxx-ng dep

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,19 +1,15 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libiconv:
 - '1.16'
 pin_run_as_build:
@@ -21,6 +17,3 @@ pin_run_as_build:
     max_pin: x.x
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @asafkahlon @mbargull
+* @asafkahlon @mbargull @xmnlab

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ Feedstock Maintainers
 
 * [@asafkahlon](https://github.com/asafkahlon/)
 * [@mbargull](https://github.com/mbargull/)
+* [@xmnlab](https://github.com/xmnlab/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,4 @@ extra:
   recipe-maintainers:
     - asafkahlon
     - mbargull
+    - xmnlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,11 @@ test:
 about:
   home: https://github.com/libfuse/libfuse
   license: LGPL-2.1-only AND GPL-2.0-only
-  license_file: LICENSE
-  license_family: LGPL
+  license_file:
+    - LICENSE
+    - LGPL2.txt
+    - GPL2.txt
+  license_family: GPL
   summary: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-Enable-building-utils-on-CentOS-6.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not linux]
   run_exports:
     # Seems to be quite stable between minor versions
@@ -22,7 +22,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - meson
     - ninja
     - pkg-config


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Just some maintenance:
- Add `LGPL2.txt`/`GPL2.txt` license files I forgot to list previously.
- Add @xmnlab to maintainers -- he probably wasn't added to the team before because he's only been listed on the `2.x` branch.
- Remove unused `{{ compiler('cxx') }}` dep and thus the `libstdcxx-ng` run dependency.
- Rebuild with `gcc=9`.